### PR TITLE
Remove clear from boon

### DIFF
--- a/forumtheme/theme/common.css
+++ b/forumtheme/theme/common.css
@@ -14,7 +14,6 @@ a { cursor: pointer; }
 
 .boon {
 	margin-bottom: 20px;
-	clear: both;
 }
 .boon .inner {
 	padding: 8px;


### PR DESCRIPTION
We shouldn't be doing `clear: both` on a class used so widely. It messes with floats a lot!