### PR TITLE
Wiki tags

### DIFF
--- a/wiki/extensions/ClanQuestWikiMarkup/ClanQuestWikiMarkup.php
+++ b/wiki/extensions/ClanQuestWikiMarkup/ClanQuestWikiMarkup.php
@@ -14,6 +14,8 @@ class ClanQuestWikiMarkup {
 		$parser->setHook('box', 'ClanQuestWikiMarkup::renderTagBox');
 		$parser->setHook('col', 'ClanQuestWikiMarkup::renderTagCol');
 		$parser->setHook('columns', 'ClanQuestWikiMarkup::renderTagColumns');
+		$parser->setHook('soundcloud', 'ClanQuestWikiMarkup::renderTagSoundCloud');
+		$parser->setHook('twitch', 'ClanQuestWikiMarkup::renderTagTwitch');
 		$parser->setHook('vimeo', 'ClanQuestWikiMarkup::renderTagVimeo');
 		$parser->setHook('youtube', 'ClanQuestWikiMarkup::renderTagYoutube');
 	}
@@ -24,26 +26,37 @@ class ClanQuestWikiMarkup {
 		return "<div class=\"boon box\"" . $style .">" . $output . "</div>\n";
 	}
 
-	public static function renderTagColumns($input, array $args, Parser $parser, PPFRame $frame) {
-		$output = $parser->recursiveTagParse($input, $frame);
-		$style = array_key_exists('style', $args) ? " style=\"" . $args['style'] . "\"" : "";
-		return "<div class=\"column-container\"" . $style . ">" . $output . "</div>\n";
-	}
-
 	public static function renderTagCol($input, array $args, Parser $parser, PPFRame $frame) {
 		$output = $parser->recursiveTagParse($input, $frame);
 		$style = array_key_exists('style', $args) ? " style=\"" . $args['style'] . "\"" : "";
 		return "<div class=\"column\"" . $style .">" . $output . "</div>\n";
 	}
 
+	public static function renderTagColumns($input, array $args, Parser $parser, PPFRame $frame) {
+		$output = $parser->recursiveTagParse($input, $frame);
+		$style = array_key_exists('style', $args) ? " style=\"" . $args['style'] . "\"" : "";
+		return "<div class=\"column-container\"" . $style . ">" . $output . "</div>\n";
+	}
+
+	public static function renderTagSoundCloud($input, array $args, Parser $parser, PPFRame $frame) {
+		$output = $parser->recursiveTagParse($input, $frame);
+		$src = "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/" . $output . " &color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true";
+		return "<iframe class=\"wiki-embed\" width=\"560\" height=\"166\" src=\"" . $src . " frameborder=\"0\" scrolling=\"no\" allow=\"autoplay\" ></iframe>\n";
+	}
+
+	public static function renderTagTwitch($input, array $args, Parser $parser, PPFRame $frame) {
+		$output = $parser->recursiveTagParse($input, $frame);
+		return "<iframe class=\"wiki-embed\" width=\"560\" height=\"315\" src=\"https://player.twitch.tv/?" . $output . "&parent=clanquest.org\" frameborder=\"0\" scrolling=\"no\" allowfullscreen></iframe>\n";
+	}
+
 	public static function renderTagYoutube($input, array $args, Parser $parser, PPFRame $frame) {
 		$output = $parser->recursiveTagParse($input, $frame);
-		return "<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/" . $output . "\" frameborder=\"0\" allow=\"autoplay; encrypted-media\" allowfullscreen></iframe>\n";
+		return "<iframe class=\"wiki-embed\" width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/" . $output . "\" frameborder=\"0\" allow=\"autoplay; encrypted-media\" allowfullscreen></iframe>\n";
 	}
 
 	public static function renderTagVimeo($input, array $args, Parser $parser, PPFRame $frame) {
 		$output = $parser->recursiveTagParse($input, $frame);
-		return "<iframe src=\"https://player.vimeo.com/video/" . $output . "\" width=\"640\" height=\"357\" frameborder=\"0\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>\n";
+		return "<iframe class=\"wiki-embed\" width=\"640\" height=\"357\" src=\"https://player.vimeo.com/video/" . $output . "\" frameborder=\"0\" allowfullscreen></iframe>\n";
 	}
 }
 ?>

--- a/wiki/extensions/ClanQuestWikiMarkup/ClanQuestWikiMarkup.php
+++ b/wiki/extensions/ClanQuestWikiMarkup/ClanQuestWikiMarkup.php
@@ -1,49 +1,49 @@
 <?php
 $wgExtensionCredits['validextensionclass'][] = array(
-    'path'           => __FILE__,
+	'path'           => __FILE__,
 	'name'           => 'Clan Quest Wiki Markup',
 	'version'        => '1.0',
-	'author'         => 'Clan Quest', 
+	'author'         => 'Clan Quest',
 	'url'            => 'https://clanquest.org/wiki',
 	'description'    => 'Provides custom wiki markup tags for the Clan Quest community.'
 );
 $wgHooks['ParserFirstCallInit'][] = 'ClanQuestWikiMarkup::onParserSetup';
 
 class ClanQuestWikiMarkup {
-    public static function onParserSetup(Parser $parser) {
-        $parser->setHook('box', 'ClanQuestWikiMarkup::renderTagBox');
-        $parser->setHook('columns', 'ClanQuestWikiMarkup::renderTagColumns');
-        $parser->setHook('col', 'ClanQuestWikiMarkup::renderTagCol');
-        $parser->setHook('youtube', 'ClanQuestWikiMarkup::renderTagYoutube');
-        $parser->setHook('vimeo', 'ClanQuestWikiMarkup::renderTagVimeo');
-    }
+	public static function onParserSetup(Parser $parser) {
+		$parser->setHook('box', 'ClanQuestWikiMarkup::renderTagBox');
+		$parser->setHook('col', 'ClanQuestWikiMarkup::renderTagCol');
+		$parser->setHook('columns', 'ClanQuestWikiMarkup::renderTagColumns');
+		$parser->setHook('vimeo', 'ClanQuestWikiMarkup::renderTagVimeo');
+		$parser->setHook('youtube', 'ClanQuestWikiMarkup::renderTagYoutube');
+	}
 
-    public static function renderTagBox($input, array $args, Parser $parser, PPFRame $frame) {
-        $output = $parser->recursiveTagParse($input, $frame);
-        $style = array_key_exists('style', $args) ? " style=\"" . $args['style'] . "\"" : "";
-        return "<div class=\"boon box\"" . $style .">" . $output . "</div>\n";
-    }
+	public static function renderTagBox($input, array $args, Parser $parser, PPFRame $frame) {
+		$output = $parser->recursiveTagParse($input, $frame);
+		$style = array_key_exists('style', $args) ? " style=\"" . $args['style'] . "\"" : "";
+		return "<div class=\"boon box\"" . $style .">" . $output . "</div>\n";
+	}
 
-    public static function renderTagColumns($input, array $args, Parser $parser, PPFRame $frame) {
-        $output = $parser->recursiveTagParse($input, $frame);
-        $style = array_key_exists('style', $args) ? " style=\"" . $args['style'] . "\"" : "";
-        return "<div class=\"column-container\"" . $style . ">" . $output . "</div>\n";
-    }
+	public static function renderTagColumns($input, array $args, Parser $parser, PPFRame $frame) {
+		$output = $parser->recursiveTagParse($input, $frame);
+		$style = array_key_exists('style', $args) ? " style=\"" . $args['style'] . "\"" : "";
+		return "<div class=\"column-container\"" . $style . ">" . $output . "</div>\n";
+	}
 
-    public static function renderTagCol($input, array $args, Parser $parser, PPFRame $frame) {
-        $output = $parser->recursiveTagParse($input, $frame);
-        $style = array_key_exists('style', $args) ? " style=\"" . $args['style'] . "\"" : "";
-        return "<div class=\"column\"" . $style .">" . $output . "</div>\n";
-    }
+	public static function renderTagCol($input, array $args, Parser $parser, PPFRame $frame) {
+		$output = $parser->recursiveTagParse($input, $frame);
+		$style = array_key_exists('style', $args) ? " style=\"" . $args['style'] . "\"" : "";
+		return "<div class=\"column\"" . $style .">" . $output . "</div>\n";
+	}
 
-    public static function renderTagYoutube($input, array $args, Parser $parser, PPFRame $frame) {
-        $output = $parser->recursiveTagParse($input, $frame);
-        return "<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/" . $output . "\" frameborder=\"0\" allow=\"autoplay; encrypted-media\" allowfullscreen></iframe>\n";
-    }
+	public static function renderTagYoutube($input, array $args, Parser $parser, PPFRame $frame) {
+		$output = $parser->recursiveTagParse($input, $frame);
+		return "<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/" . $output . "\" frameborder=\"0\" allow=\"autoplay; encrypted-media\" allowfullscreen></iframe>\n";
+	}
 
-    public static function renderTagVimeo($input, array $args, Parser $parser, PPFRame $frame) {
-        $output = $parser->recursiveTagParse($input, $frame);
-        return "<iframe src=\"https://player.vimeo.com/video/" . $output . "\" width=\"640\" height=\"357\" frameborder=\"0\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>\n";
-    }
+	public static function renderTagVimeo($input, array $args, Parser $parser, PPFRame $frame) {
+		$output = $parser->recursiveTagParse($input, $frame);
+		return "<iframe src=\"https://player.vimeo.com/video/" . $output . "\" width=\"640\" height=\"357\" frameborder=\"0\" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>\n";
+	}
 }
 ?>


### PR DESCRIPTION
This PR adds two new tags to the wiki for embedding Soundcloud and Twitch.

Some notes:

* I made sure the file is fully indented with tabs. It used a mix of tabs and spaces before.
* I tried keeping the order of the iframe parameters a bit consistent to make it easier to compare.
* The Twitch embed had no width and height, so I copied the YouTube dimensions. The Soundcloud embed wanted to go width 100%, so I also dropped that to the width of a YouTube embed. We probably need to do another pass to make sure the embeds work fine on mobile and don't drop out of the page width bound.
* I added a shared css class to all iframes so we can do some common styling if we so desire.

Feel free to squash and merge.